### PR TITLE
Prevent error message when creating records

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faims3-datamodel",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Database access layer for FAIMS3",
   "main": "./build/src/index.js",
   "exports": {

--- a/src/data_storage/index.ts
+++ b/src/data_storage/index.ts
@@ -44,7 +44,7 @@ import {
 import {shouldDisplayRecord} from '../index';
 import {
   addNewRevisionFromForm,
-  createNewRecord,
+  createNewRecordIfMissing,
   generateFAIMSRevisionID,
   getRecord,
   getRevision,
@@ -89,8 +89,7 @@ export async function upsertFAIMSData(
   }
   const revision_id = generateFAIMSRevisionID();
   if (record.revision_id === null) {
-    // console.info('New record', record);
-    await createNewRecord(project_id, record, revision_id);
+    await createNewRecordIfMissing(project_id, record, revision_id);
     await addNewRevisionFromForm(project_id, record, revision_id);
   } else {
     // console.info('Update existing record', record);

--- a/src/data_storage/internals.ts
+++ b/src/data_storage/internals.ts
@@ -491,7 +491,9 @@ async function addNewAttributeValuePairs(
   return avp_map;
 }
 
-export async function createNewRecord(
+// add a new empty record if not already present
+// used to initialise a new record before data is added with addNewRevisionFromForm
+export async function createNewRecordIfMissing(
   project_id: ProjectID,
   record: Record,
   revision_id: RevisionID
@@ -509,9 +511,8 @@ export async function createNewRecord(
   try {
     await dataDB.put(new_encoded_record);
   } catch (err) {
-    // TODO: add proper error handling for conflicts
-    console.warn(err);
-    throw Error('failed to create record document');
+    // if there was an error then the document exists
+    // already which is fine
   }
 }
 


### PR DESCRIPTION
We get 'Can't save record' errors when saving works fine due to a confused bit of code.  Here we change the name of the fn to createNewRecordIfMissing since that is what it does and have it not throw an error if the record is already there.

Signed-off-by: Steve Cassidy <steve.cassidy@mq.edu.au>